### PR TITLE
feature: Add similar breeds to detail screen

### DIFF
--- a/app/src/main/java/com/example/catbreeds/MainActivity.kt
+++ b/app/src/main/java/com/example/catbreeds/MainActivity.kt
@@ -76,7 +76,10 @@ fun AppContent() {
                 val breedId = backStackEntry.arguments?.getString("breedId")
                 breedId?.let {
                     BreedDetailScreen(
-                        onBackClick = { navController.popBackStack() }
+                        onBackClick = { navController.popBackStack() },
+                        onBreedClick = { similarBreedId ->
+                            navController.navigate(Screen.BreedDetail.createRoute(similarBreedId))
+                        }
                     )
                 }
             }

--- a/data/src/main/java/com/example/catbreeds/data/repository/BreedRepositoryImpl.kt
+++ b/data/src/main/java/com/example/catbreeds/data/repository/BreedRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.example.catbreeds.domain.repository.BreedRepository
 import com.example.catbreeds.core.util.ConnectivityChecker
 import com.example.catbreeds.core.util.ErrorMessages
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
@@ -76,6 +77,22 @@ class BreedRepositoryImpl(
                 localSource.getById(favoriteEntity.id)?.toBreed(isFavorite = true)
             }
             emit(favoriteBreeds)
+        }
+    }
+
+    override fun getSimilarBreeds(breedId: String): Flow<List<Breed>> {
+        return flow {
+            val breed = getBreedById(breedId)
+            if (breed != null) {
+                val allBreeds = getBreeds().first()
+                val temperamentList = breed.temperament.split(", ")
+                val similar = allBreeds.filter {
+                    it.id != breed.id && (it.origin == breed.origin || it.temperament.split(", ").count { temperament -> temperamentList.contains(temperament) } >= 3)
+                }.take(6)
+                emit(similar)
+            } else {
+                emit(emptyList())
+            }
         }
     }
 }

--- a/domain/src/main/java/com/example/catbreeds/domain/repository/BreedRepository.kt
+++ b/domain/src/main/java/com/example/catbreeds/domain/repository/BreedRepository.kt
@@ -10,4 +10,5 @@ interface BreedRepository {
     suspend fun addBreedToFavorites(breedId : String)
     suspend fun removeBreedFromFavorites(breedId : String)
     fun getFavoriteBreeds(): Flow<List<Breed>>
+    fun getSimilarBreeds(breedId: String): Flow<List<Breed>>
 }

--- a/features/breed_detail/src/main/java/com/example/catbreeds/breed_detail/BreedDetailScreen.kt
+++ b/features/breed_detail/src/main/java/com/example/catbreeds/breed_detail/BreedDetailScreen.kt
@@ -39,14 +39,25 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.example.catbreeds.core.util.ErrorHandler
+import com.example.catbreeds.domain.models.Breed
+import androidx.compose.material3.Card
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.clickable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BreedDetailScreen(
     viewModel: BreedDetailViewModel = hiltViewModel(),
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onBreedClick: (String) -> Unit
 ) {
     val breed by viewModel.breed
+    val similarBreeds by viewModel.similarBreeds
 
     // To handle snackbar and error messages
     val errorMessage by viewModel.errorMessage
@@ -148,6 +159,31 @@ fun BreedDetailScreen(
                         lineHeight = 24.sp
                     )
                 }
+
+                // Similar Breeds
+                if (similarBreeds.isNotEmpty()) {
+                    Column {
+                        Text(
+                            text = "Similar Breeds",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        LazyHorizontalGrid(
+                            rows = GridCells.Fixed(1),
+                            modifier = Modifier.height(180.dp),
+                            contentPadding = PaddingValues(end = 16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(similarBreeds) { similarBreed ->
+                                SimilarBreedCard(
+                                    breed = similarBreed,
+                                    onClick = { onBreedClick(similarBreed.id) }
+                                )
+                            }
+                        }
+                    }
+                }
             }
         } ?: run {
             Box(
@@ -158,6 +194,38 @@ fun BreedDetailScreen(
             ) {
                 CircularProgressIndicator()
             }
+        }
+    }
+}
+
+@Composable
+fun SimilarBreedCard(
+    breed: Breed,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .width(150.dp)
+            .clickable { onClick() }
+    ) {
+        Column {
+            AsyncImage(
+                model = "https://cdn2.thecatapi.com/images/${breed.reference_image_id}.jpg",
+                contentDescription = "Image of ${breed.name}",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(130.dp)
+                    .clip(RoundedCornerShape(8.dp, 8.dp, 0.dp, 0.dp)),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(id = R.drawable.ic_menu_report_image),
+                error = painterResource(id = R.drawable.ic_menu_close_clear_cancel)
+            )
+            Text(
+                text = breed.name,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(8.dp)
+            )
         }
     }
 }

--- a/features/breed_detail/src/main/java/com/example/catbreeds/breed_detail/BreedDetailViewModel.kt
+++ b/features/breed_detail/src/main/java/com/example/catbreeds/breed_detail/BreedDetailViewModel.kt
@@ -23,6 +23,9 @@ class BreedDetailViewModel @Inject constructor(
     val breed: State<Breed?> = _breed
     private val breedId = savedStateHandle.get<String>("breedId")
 
+    private val _similarBreeds = mutableStateOf<List<Breed>>(emptyList())
+    val similarBreeds: State<List<Breed>> = _similarBreeds
+
     private val _errorMessage = mutableStateOf<String?>(null)
     val errorMessage: State<String?> = _errorMessage
 
@@ -30,6 +33,7 @@ class BreedDetailViewModel @Inject constructor(
         breedId?.let { id ->
             fetchBreedDetail(id)
             observeFavorites(id)
+            fetchSimilarBreeds(id)
         }
     }
 
@@ -54,6 +58,14 @@ class BreedDetailViewModel @Inject constructor(
                     val isFavorite = favoriteBreeds.any { it.id == breedId }
                     _breed.value = currentBreed.copy(isFavorite = isFavorite)
                 }
+            }
+        }
+    }
+
+    private fun fetchSimilarBreeds(breedId: String) {
+        viewModelScope.launch {
+            breedRepository.getSimilarBreeds(breedId).collectLatest {
+                _similarBreeds.value = it
             }
         }
     }


### PR DESCRIPTION
Create new 'Similar Breeds' carrousel on breed detail screen
- Displays up to 6 breeds with either the same origin or up at least 3 similar 'temperaments'.